### PR TITLE
Make the compiler substitutable

### DIFF
--- a/gameSource/Makefile.all
+++ b/gameSource/Makefile.all
@@ -1,8 +1,8 @@
 
 ROOT_PATH = ../..
 
-COMPILE = g++ ${PLATFORM_COMPILE_FLAGS} -Wall -Wwrite-strings -Wchar-subscripts -Wparentheses -g -I${ROOT_PATH} -c
-LINK = g++ -I${ROOT_PATH}
+COMPILE = $(CXX) ${PLATFORM_COMPILE_FLAGS} -Wall -Wwrite-strings -Wchar-subscripts -Wparentheses -g -I${ROOT_PATH} -c
+LINK = $(CXX) -I${ROOT_PATH}
 
 
 

--- a/prototypes/screenCompress/Makefile
+++ b/prototypes/screenCompress/Makefile
@@ -2,8 +2,8 @@
 
 ROOT_PATH = ../../..
 
-COMPILE = g++ -g -I${ROOT_PATH} -c
-LINK = g++ -I${ROOT_PATH}
+COMPILE = $(CXX) -g -I${ROOT_PATH} -c
+LINK = $(CXX) -I${ROOT_PATH}
 
 
 


### PR DESCRIPTION
This allows cross-compilation of the binary between different architectures.

Fixes: https://bugs.debian.org/923269
